### PR TITLE
Enable running of benchmarks using mx.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Compiled class file
 *.class
 
+# Python
+__pycache__/
+*.pyc
+
 # Log file
 *.log
 

--- a/mx.heap-language/suite.py
+++ b/mx.heap-language/suite.py
@@ -1,0 +1,4 @@
+suite = {
+  "mxversion" : "5.264.3",
+  "name" : "heap-language"
+}


### PR DESCRIPTION
By adding an `mx` suite in that repo, `mx benchmark` will be able to automatically extract commit information from it.

If the graal repository is cloned side by side with this repo, one can build and run the jmh generated benchmarks like this :

```
$ cd heap-language/
$ ./gradlew :jmh-benchmark:shadowJar
$ mx --dy /compiler benchmark --ignore-suite-commit-info heap-language jmh-jar -- --jvm server --jvm-config graal-core --jmh-jar=./jmh-benchmark/build/libs/jmh-benchmark-all.jar --jmh-name=heap-language -- -f 1 -wi 0 -i 1 -r 2
```

This will generate a `bench-results.json` file with the main commit information being the ones from the `heap-language` repo. Adding `--ignore-suite-commit-info heap-language` prevents from duplicating this data under a secondary name in the results file.

Here is part of the relevant section of the results file : 
```      "bench-suite": "jmh-heap-language",
      "benchmark": "b.Bench.oldEngine",
      "benchmarking.end-ts": 1591438714,
      "benchmarking.start-ts": 1591438677,
      "branch": "master",
      "commit.author": "Samuel Pastva <sam.pastva@gmail.com>",
      "commit.author-ts": 1591354464,
      "commit.committer": "Samuel Pastva <sam.pastva@gmail.com>",
      "commit.committer-ts": 1591354464,
      "commit.repo-url": "git@github.com:farquet/heap-language.git",
      "commit.rev": "49475454125fa2e59b04b9211f1d51240dba6b60",
      "compiler.commit.author": "Francois Farquet <francois.farquet@oracle.com>",
      "compiler.commit.author-ts": 1591374614,
      "compiler.commit.committer": "Francois Farquet <francois.farquet@oracle.com>",
      "compiler.commit.committer-ts": 1591374614,
      "compiler.commit.repo-url": "ssh://git@ol-bitbucket.us.oracle.com:7999/g/graal.git",
      "compiler.commit.rev": "93db0ee1a8d46bd8500ef5118495ec4c7f438226",
```